### PR TITLE
docs/ci: Doxygen site/ + GitHub Pages kurulumu

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Bu yeni `README.md` dosyası, `pico_training_board.h` dosyasındaki güncel veri
 
 ## Dokümantasyon Üretimi (Doxygen)
 
-Bu proje Doxygen ile belgelenmiştir. HTML ve LaTeX çıktıları `./docs` klasörüne üretilir.
+Bu proje Doxygen ile belgelenmiştir. Çıktılar GitHub Pages ile uyumlu olacak şekilde `site/` dizinine üretilir.
 
 Gereksinimler:
 
@@ -180,13 +180,14 @@ doxygen Doxyfile
 
 Çıktılar:
 
-- HTML: `docs/html/index.html`
-- LaTeX: `docs/latex/`
+- HTML: `site/index.html`
+- LaTeX: Üretilmez (devre dışı)
 
 Notlar:
 
 - Doxygen Türkçe dil dosyası eski uyarısı görülebilir; işlevi etkilemez.
-- Dot kaynaklı hatalar varsa önce `docs/html` ve `docs/latex` dizinlerini silip tekrar çalıştırın.
+- Dot kaynaklı hatalar varsa önce `site/` dizinini temizleyip tekrar çalıştırın.
+- GitHub Actions, `main` branch’e merge sonrası `site/` çıktısını otomatik olarak GitHub Pages’e yayınlayacak şekilde yapılandırılmıştır.
 
 ## Sorun Giderme (Doxygen)
 


### PR DESCRIPTION
Bu PR, Doxygen belgelerini `site/` altına çıkacak şekilde yapılandırır, Graphviz çağrı/çağıran grafikleri için etkindir. Ayrıca GitHub Actions ile `main` dalına merge sonrası otomatik GitHub Pages yayını sağlar.

Öne çıkanlar:
- Doxyfile: OUTPUT_DIRECTORY=site, GENERATE_LATEX=NO, ağaç görünümü ve ana sayfa ayarları
- Workflow: CI yapısı - build + deploy (deploy sadece `main`)
- .gitignore: build/, site/, .DS_Store, .vscode/
- README: Çıktı yollarını site/ ile uyumlu hale getirildi

Not: Ortam koruması nedeniyle feature dallarından Pages deploy tetiklenmez; build koşar, deploy merge sonrası `main`'de gerçekleşir.